### PR TITLE
Ignore insets on hidden views

### DIFF
--- a/LayoutEngine/LayoutEngine.swift
+++ b/LayoutEngine/LayoutEngine.swift
@@ -16,22 +16,24 @@ public struct LayoutEngine {
       if let view = layout.view {
         layout.setHidden(layout.metric.hidden, view)
       }
+      var viewFrame = frame
 
-      frame.size = layout.size(insetWidth)
-      frame.origin.y += layout.insets.top
+      viewFrame.size = layout.size(insetWidth)
+      viewFrame.origin.y += layout.insets.top
 
       if let view = layout.view {
         switch layout.direction {
         case .Left:
-          frame.origin.x = insets.left + layout.insets.left
+          viewFrame.origin.x = insets.left + layout.insets.left
         case .Right:
-          frame.origin.x = width - frame.width - insets.right - layout.insets.right
+          viewFrame.origin.x = width - viewFrame.width - insets.right - layout.insets.right
         }
-          view.frame = frame
+          view.frame = viewFrame
       }
       if layout.metric.hidden == false {
-        frame.origin.y += layout.insets.bottom
-        frame.origin.y += frame.size.height
+        viewFrame.origin.y += layout.insets.bottom
+        viewFrame.origin.y += viewFrame.size.height
+        frame = viewFrame
       }
     }
 

--- a/LayoutEngineTests/LayoutEngineTests.swift
+++ b/LayoutEngineTests/LayoutEngineTests.swift
@@ -81,6 +81,18 @@ class LayoutEngineTests: QuickSpec {
           expect(height).to(equal(20))
         }
 
+        it("ignores insets on hidden views") {
+          let firstMetric = ViewDefaultMetric(
+            insets: UIEdgeInsets(top: 10, left: 10, bottom: 10, right: 10),
+            hidden: true)
+
+          let firstLayout = ViewLayout(view: firstView, metric: firstMetric)
+          let secondLayout = ViewLayout(view: secondView)
+          let height = LayoutEngine.stackViews([firstLayout, secondLayout], width: 320)
+          expect(firstView.hidden).to(beTrue())
+          expect(secondView.frame.origin.y).to(equal(0))
+          expect(height).to(equal(20))
+        }
       }
 
     }


### PR DESCRIPTION
We only want to consider insets for the hidden view, not for following
views. We're using the inset to position hidden views in near proximity
where they're suppose to be, and therefor need to consider it for the
actual hidden view.
e
